### PR TITLE
Add intiial dotnet appium test (#3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# node modules
+node_modules
+
+# dotnet
+obj
+bin

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,19 @@
-.PHONY: test
+.PHONY: install start-appium run-tests all
+
+install:
+	@echo "Installing dependencies..."
+	cd appium-nodejs && npm i
+	@echo "Installing dotnet dependencies..."
+	cd appium-dotnet && dotnet restore --no-cache
 
 start-appium:
 	@echo "Starting Appium server..."
 	appium --log-timestamp
 
-run-node-tests:
+run-tests:
 	@echo "Running npm tests..."
 	cd appium-nodejs && npm run test
+	@echo "Running dotnet tests..."
+	cd appium-dotnet && dotnet test --logger "console;verbosity=normal"
 
-test: start-appium run-node-tests
+all: install run-tests

--- a/appium-dotnet/GlobalUsings.cs
+++ b/appium-dotnet/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using NUnit.Framework;

--- a/appium-dotnet/README.md
+++ b/appium-dotnet/README.md
@@ -1,0 +1,59 @@
+# Appium C# (.NET) Test Example
+
+This is a simple Appium test using C# (.NET) and NUnit.
+
+This test:
+1. Defines capabilities for the Appium server
+2. Starts an Appium session on the Android settings app
+3. Finds and clicks the "Battery" list item
+4. Pauses briefly for visual effect
+5. Ends the Appium session
+
+
+## Packages
+
+The project uses the following NuGet packages:
+
+- Appium.WebDriver (5.1.0)
+- Microsoft.NET.Test.Sdk (17.6.0)
+- Newtonsoft.Json (13.0.3)
+- NUnit (3.13.3)
+- NUnit3TestAdapter (4.2.1)
+- NUnit.Analyzers (3.6.1)
+- coverlet.collector (6.0.0)
+
+## Prerequisites
+
+- .NET SDK installed
+- Appium server set up and running
+- Android device or emulator connected
+
+## Setup
+
+1. Clone this repo:
+
+   ```shell
+   git clone https://github.com/tooniez/appium-framework.git
+   ```
+
+2. Navigate to the project directory:
+
+   ```shell
+   cd appium-dotnet/
+   ```
+
+3. Restore dependencies:
+
+   ```shell
+   dotnet restore
+   ```
+
+## Running the Test
+
+Ensure your Appium server is running, then:
+
+1. Run the test:
+
+   ```shell
+   dotnet test
+   ```

--- a/appium-dotnet/UnitTest1.cs
+++ b/appium-dotnet/UnitTest1.cs
@@ -1,15 +1,43 @@
-namespace appium_dotnet;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Appium;
+using OpenQA.Selenium.Appium.Android;
+using OpenQA.Selenium.Appium.Enums;
+
+namespace appiumtest;
 
 public class Tests
 {
-    [SetUp]
-    public void Setup()
+    private AndroidDriver _driver;
+
+    [OneTimeSetUp]
+    public void SetUp()
     {
+        var serverUri = new Uri(Environment.GetEnvironmentVariable("APPIUM_HOST") ?? "http://127.0.0.1:4723/");
+        var driverOptions = new AppiumOptions() {
+            AutomationName = AutomationName.AndroidUIAutomator2,
+            PlatformName = "Android",
+            DeviceName = "Android Emulator",
+        };
+
+        driverOptions.AddAdditionalAppiumOption("appPackage", "com.android.settings");
+        driverOptions.AddAdditionalAppiumOption("appActivity", ".Settings");
+        // NoReset assumes the app com.google.android is preinstalled on the emulator
+        driverOptions.AddAdditionalAppiumOption("noReset", true);
+
+        _driver = new AndroidDriver(serverUri, driverOptions, TimeSpan.FromSeconds(180));
+        _driver.Manage().Timeouts().ImplicitWait = TimeSpan.FromSeconds(10);
+    }
+
+    [OneTimeTearDown]
+    public void TearDown()
+    {
+        _driver.Dispose();
     }
 
     [Test]
-    public void Test1()
+    public void TestBattery()
     {
-        Assert.Pass();
+        _driver.StartActivity("com.android.settings", ".Settings");
+        _driver.FindElement(By.XPath("//*[@text='Battery']")).Click();
     }
 }

--- a/appium-dotnet/UnitTest1.cs
+++ b/appium-dotnet/UnitTest1.cs
@@ -1,0 +1,15 @@
+namespace appium_dotnet;
+
+public class Tests
+{
+    [SetUp]
+    public void Setup()
+    {
+    }
+
+    [Test]
+    public void Test1()
+    {
+        Assert.Pass();
+    }
+}

--- a/appium-dotnet/appium-dotnet.csproj
+++ b/appium-dotnet/appium-dotnet.csproj
@@ -11,7 +11,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Appium.WebDriver" Version="5.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="NUnit.Analyzers" Version="3.6.1" />

--- a/appium-dotnet/appium-dotnet.csproj
+++ b/appium-dotnet/appium-dotnet.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <RootNamespace>appium_dotnet</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.6.1" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/appium-nodejs/README.md
+++ b/appium-nodejs/README.md
@@ -10,6 +10,12 @@ This test:
 4. Pauses briefly for visual effect
 5. Ends the Appium session
 
+## Packages
+
+The project uses the following npm packages:
+
+- webdriverio
+
 ## Prerequisites
 
 - Node.js and npm installed


### PR DESCRIPTION
### 🚀 What does this PR do?

This pull request adds initial appium dotnet test

Changes:
 • Added .gitignore file to ignore node_modules and obj directories.
 • Updated Makefile to include new targets for installing dependencies, starting Appium server, running tests, and all.

Created new files:
    • appium-dotnet/GlobalUsings.cs: defines global using statements for NUnit framework.
    • appium-dotnet/README.md: provides instructions for setting up the project and running tests.
    • appium-dotnet/UnitTest1.cs: contains test cases for Appium Android settings app.
    • appium-dotnet/appium-dotnet.csproj: updated project file to include necessary NuGet packages.

### 🎫 Related Issue 

#3
  
### ✅ Definition of Done:
<!-- Please review https://docs.adobe.com/content/help/en/target/using/implement-target/activities/test/plan-a-b-test-understand-dov.html -->

- [x] Code changes have been tested in a local environment
- [x] Pull request has a descriptive title and information useful to a reviewer
- [x] Relevant documentation has been updated
